### PR TITLE
task(Relay):No-Ticket - Update relay name for postfix metrics

### DIFF
--- a/collectors/python.d.plugin/postfix/postfix_log.chart.py
+++ b/collectors/python.d.plugin/postfix/postfix_log.chart.py
@@ -87,7 +87,7 @@ class Service(LogService):
         else:
             self.reRelay = re.compile(f'relay={self.relay}')
 
-        filter_relay = self.configuration.get('email_counter_relay', 'pbfilter')
+        filter_relay = self.configuration.get('email_counter_relay', '127.0.0.1')
         self.reFilterRelay = re.compile(f'relay={filter_relay}')
 
 

--- a/collectors/python.d.plugin/postfix/postfix_log.conf
+++ b/collectors/python.d.plugin/postfix/postfix_log.conf
@@ -71,6 +71,6 @@ update_every: 60
 local:
   delay_window_span: [2400, 10800]
   log_path: /var/log/mail.log
-  relay: pbfilter
-  email_counter_relay: pbfilter
+  relay: 127.0.0.1
+  email_counter_relay: 127.0.0.1
   


### PR DESCRIPTION
`pbinbound` and `pboutbound` both run on and are identified as relay `127.0.0.1`